### PR TITLE
Add VCINSTALLDIR to list of exported variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const InterestingVariables = [
     'INCLUDE',
     'LIB',
     'LIBPATH',
+    'VCINSTALLDIR',
     'Path',
     'Platform',
     'VisualStudioVersion',


### PR DESCRIPTION
This should allow windeployqt to pick up the exported environment variable. See #22